### PR TITLE
Add Terraform setup with Lambda and workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy Infrastructure
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: us-east-1
+      - run: terraform -chdir=terraform init
+      - run: terraform -chdir=terraform apply -auto-approve

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,0 +1,20 @@
+name: Destroy Infrastructure
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: us-east-1
+      - run: terraform -chdir=terraform init
+      - run: terraform -chdir=terraform destroy -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+terraform/lambda.zip
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # openai-with-aws-test6
+
+This repository provisions an S3 bucket, Lambda function and API Gateway using Terraform. Infrastructure is deployed via GitHub Actions using OIDC.
+
+## Infrastructure
+- **S3 Bucket**: `ontoscale-create-with-openai-codex`
+- **Lambda**: writes a file to the bucket when triggered
+- **API Gateway**: exposes an endpoint at `/create-file` that triggers the Lambda
+
+Terraform backend is stored in `ontoscale-terraform-backend` (S3) in `us-east-1`.
+
+## Workflows
+- `Deploy Infrastructure` runs on merge to `main` and applies Terraform configuration.
+- `Destroy Infrastructure` can be triggered manually from the Actions tab.
+
+Set the secret `AWS_ROLE` in GitHub to the role ARN used for deployment.

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -1,0 +1,15 @@
+import json
+import os
+from datetime import datetime
+import boto3
+
+s3 = boto3.client('s3')
+bucket = os.environ.get('BUCKET_NAME')
+
+def lambda_handler(event, context):
+    key = f"file_{datetime.utcnow().isoformat()}.txt"
+    s3.put_object(Bucket=bucket, Key=key, Body="created by lambda")
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"message": "File created", "key": key})
+    }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  backend "s3" {
+    bucket = "ontoscale-terraform-backend"
+    key    = "openai-with-aws-test6/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket        = "ontoscale-create-with-openai-codex"
+  force_destroy = true
+}
+
+# IAM role for Lambda
+resource "aws_iam_role" "lambda_role" {
+  name               = "lambda-s3-file-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "lambda_policy" {
+  statement {
+    actions   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:*:*:*"]
+  }
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.bucket.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_policy" {
+  role   = aws_iam_role.lambda_role.id
+  policy = data.aws_iam_policy_document.lambda_policy.json
+}
+
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/../lambda"
+  output_path = "${path.module}/lambda.zip"
+}
+
+resource "aws_lambda_function" "lambda" {
+  function_name    = "s3_file_creator"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "python3.9"
+  filename         = data.archive_file.lambda_zip.output_path
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  environment {
+    variables = {
+      BUCKET_NAME = aws_s3_bucket.bucket.id
+    }
+  }
+}
+
+resource "aws_apigatewayv2_api" "api" {
+  name          = "lambda-api"
+  protocol_type = "HTTP"
+}
+
+resource "aws_lambda_permission" "api_gateway" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
+}
+
+resource "aws_apigatewayv2_integration" "lambda_integration" {
+  api_id                 = aws_apigatewayv2_api.api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.lambda.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "default" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "GET /create-file"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda_integration.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.api.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+output "api_endpoint" {
+  value = aws_apigatewayv2_stage.default.invoke_url
+}


### PR DESCRIPTION
## Summary
- set up Terraform to provision an S3 bucket, Lambda and API Gateway
- add Lambda function in Python to write files to the bucket
- configure GitHub Actions for deploy and destroy using OIDC
- document usage in README

## Testing
- `terraform -chdir=terraform fmt -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_68768ed0f668833199c8c03b05c9ec8f